### PR TITLE
Fixed name for dependency "textobj-user"

### DIFF
--- a/addon-info.json
+++ b/addon-info.json
@@ -6,7 +6,7 @@
     "url": "git://github.com/rbonvall/vim-textobj-latex"
   },
   "dependencies" : {
-    "vim-textobj-user": {
+    "textobj-user": {
       "type": "git",
       "url": "git://github.com/kana/vim-textobj-user"
     }


### PR DESCRIPTION
Hi,

I fixed the name of the "textobj-user" dependency in addon-info.json.

For VAM, the plugin names at vim.org are canonical and there the plugin is called "textobj-user". This is in fact the official name: try `:h textobj-user`. The "vim-" is just a prefix people on Github use to mark their Vim plugin repos.

For consistency you may want to change this line in the same fashion, but that's up to you:

```
"name" : "vim-textobj-latex"
```
