### PR TITLE
Add text object for paragraphs neighbouring environments

### DIFF
--- a/ftplugin/tex/textobj-latex.vim
+++ b/ftplugin/tex/textobj-latex.vim
@@ -25,21 +25,21 @@ endfunction
 
 
 call textobj#user#plugin('latex', {
-\  'environment': {
-\    '*pattern*': [s:re_begin, s:re_end],
-\    'select-a': 'ae',
-\    'select-i': 'ie',
-\  },
-\  'outside-environ': {
-\    '*sfile*': expand('<sfile>:p'),
-\    'select-a': 'ar',  '*select-a-function*': 's:select_a',
-\    'select-i': 'ir',  '*select-i-function*': 's:select_i'
-\  },
-\  'bracket-math': {
-\    '*pattern*': ['\\\[', '\\\]'],
-\    'select-a': 'ab',
-\    'select-i': 'ib',
-\  },
+\   'environment': {
+\     '*pattern*': ['\\begin{[^}]\+}.*\n\s*', '\n^\s*\\end{[^}]\+}.*$'],
+\     'select-a': 'ae',
+\     'select-i': 'ie',
+\   },
+\   'outside-environ': {
+\     '*sfile*': expand('<sfile>:p'),
+\     'select-a': 'ar',  '*select-a-function*': 's:select_a',
+\     'select-i': 'ir',  '*select-i-function*': 's:select_i'
+\   },
+\   'bracket-math': {
+\     '*pattern*': ['\\\[', '\\\]'],
+\     'select-a': 'ab',
+\     'select-i': 'ib',
+\   },
 \  'paren-math': {
 \     '*pattern*': ['\\(', '\\)'],
 \     'select-a': 'a\',

--- a/ftplugin/tex/textobj-latex.vim
+++ b/ftplugin/tex/textobj-latex.vim
@@ -7,17 +7,39 @@ if exists('g:loaded_textobj_latex')
   finish
 endif
 
+let s:re_begin = '\\begin{[^}]\+}'
+let s:re_end = '\\end{[^}]\+}'
+
+
+"
+" Join alternatives for a regular expression
+function! s:ReJoin(...)
+  return join(a:000, '\|')
+endfunction
+
+"
+" Make sure RE matches whole line
+function! s:ReWholeLine(re)
+  return '^\('.a:re.'\)\n'
+endfunction
+
+
 call textobj#user#plugin('latex', {
-\   'environment': {
-\     '*pattern*': ['\\begin{[^}]\+}.*\n\s*', '\n^\s*\\end{[^}]\+}.*$'],
-\     'select-a': 'ae',
-\     'select-i': 'ie',
-\   },
+\  'environment': {
+\    '*pattern*': [s:re_begin, s:re_end],
+\    'select-a': 'ae',
+\    'select-i': 'ie',
+\  },
+\  'outside-environ': {
+\    '*sfile*': expand('<sfile>:p'),
+\    'select-a': 'ar',  '*select-a-function*': 's:select_a',
+\    'select-i': 'ir',  '*select-i-function*': 's:select_i'
+\  },
 \  'bracket-math': {
-\     '*pattern*': ['\\\[', '\\\]'],
-\     'select-a': 'ab',
-\     'select-i': 'ib',
-\   },
+\    '*pattern*': ['\\\[', '\\\]'],
+\    'select-a': 'ab',
+\    'select-i': 'ib',
+\  },
 \  'paren-math': {
 \     '*pattern*': ['\\(', '\\)'],
 \     'select-a': 'a\',
@@ -43,5 +65,30 @@ call textobj#user#plugin('latex', {
 \   },
 \ })
 
-let g:loaded_textobj_latex = 1
 
+function! s:select_a()
+  " echom s:ReWholeLine(s:ReJoin(s:re_end, ''))
+  let start_pos = search(s:ReWholeLine(s:ReJoin(s:re_end, '')), 'bnW')
+  if 0 == start_pos
+    return 0  " We did not find the start of the text object
+  endif
+  let end_pos = search(s:ReWholeLine(s:ReJoin(s:re_begin, '')), 'nW')
+  if 0 == end_pos
+    return 0  " We did not find the end of the text object
+  endif
+  return ['V', [0, start_pos, 0, 0], [0, end_pos, 0, 0]]
+endfunction
+
+function! s:select_i()
+  let start_pos = search(s:ReWholeLine(s:ReJoin(s:re_end, '')), 'bnW')
+  if 0 == start_pos
+    return 0  " We did not find the start of the text object
+  endif
+  let end_pos = search(s:ReWholeLine(s:ReJoin(s:re_begin, '')), 'nW')
+  if 0 == end_pos
+    return 0  " We did not find the end of the text object
+  endif
+  return ['V', [0, start_pos + 1, 0, 0], [0, end_pos - 1, 0, 0]]
+endfunction
+
+let g:loaded_textobj_latex = 1


### PR DESCRIPTION
Often I want to format a paragraph such as this one:
```
\begin{align}
...
\end{align}
This is
the paragraph
I wish
to format.....
```
So I added a text object so that I could do `gwir` to format it. I am quite new to vim scripting so I'm not sure that I've done everything the best way ;) Hopefully others might find it useful.